### PR TITLE
docs(jeeves): add local OpenClaw runner smoke-test rules

### DIFF
--- a/projects/jeeves/openclaw_runner/collaboration_technology_v1.md
+++ b/projects/jeeves/openclaw_runner/collaboration_technology_v1.md
@@ -224,6 +224,19 @@ Files/directories/modules that may be changed.
 - next recommendation
 ```
 
+### 7.1 Codex exec sandbox rules
+
+Read-only tasks may use `codex exec` without `workspace-write`.
+
+Write tasks must:
+
+```text
+- explicitly use codex exec --sandbox workspace-write
+- state the allowed files and scope
+- never use workspace-write with vague prompts such as "..."
+- run git status and git diff after every write task
+```
+
 ## 8. Executor output contract
 
 Every OpenClaw/Codex run must end with a machine-readable or clearly structured summary:

--- a/projects/jeeves/openclaw_runner/local_write_smoke_test.md
+++ b/projects/jeeves/openclaw_runner/local_write_smoke_test.md
@@ -1,0 +1,11 @@
+# Local Write Smoke Test
+
+Date: 2026-04-26
+Executor: OpenClaw via Codex CLI
+Result: local write path verified
+
+Rules:
+- no production secrets
+- no main branch writes
+- no deployment
+- no commits without review


### PR DESCRIPTION
## Summary
- Adds a local write smoke-test file for the OpenClaw + Codex workflow.
- Documents Codex sandbox rules for OpenClaw runner tasks.

## Validation
- Local OpenClaw gateway works via systemd on WSL2.
- OpenClaw LLM provider works through openai-codex/gpt-5.5.
- Codex CLI read-only task passed.
- Codex CLI workspace-write task passed.
- Git worktree was clean before push.

## Safety notes
- OpenClaw remains a controlled dev-runner, not product core.
- Write tasks must explicitly use `codex exec --sandbox workspace-write`.
- Main branch, production secrets, deployment, and unscoped write tasks remain forbidden.