### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md
+++ b/projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md
@@ -1,0 +1,143 @@
+# Agent Runner Lane Docs Verifier Test Result v1
+
+Date: 2026-04-30
+Repository: `alanua/Knowledge-base`
+Verifier: `scripts/agent-dept/agent-dept-verify-lane-docs`
+Task type: controlled `lane:docs` `risk:yellow` documentation verification
+
+## Scope
+
+This result documents a controlled verification of the merged read-only lane docs verifier.
+
+No live runner scripts, service files, deployment paths, secrets, SSH keys, environment values, or runtime systems were edited or accessed. No commit, push, merge, deployment, or PR creation was performed by this task.
+
+## Required Command Results
+
+| Command | Exit | Result | Notes |
+| --- | ---: | --- | --- |
+| `git diff --check` | 0 | Pass | No whitespace errors reported. |
+| `bash -n scripts/agent-dept/agent-dept-verify-lane-docs` | 0 | Pass | Bash syntax check completed without output. |
+| `scripts/agent-dept/agent-dept-verify-lane-docs --self-test` | 0 | Pass | All built-in self-test cases passed. |
+
+Self-test output:
+
+```text
+self_test=accept_valid_yellow status=pass
+self_test=reject_wrong_repo status=pass
+self_test=reject_wrong_lane status=pass
+self_test=reject_forbidden_file status=pass
+self_test=reject_index_without_scope status=pass
+SELF_TEST_PASS
+```
+
+## Manual Verification Cases
+
+| Case | Command summary | Exit | Observed decision | Reason code |
+| --- | --- | ---: | --- | --- |
+| Valid yellow docs task is accepted | `--repo alanua/Knowledge-base --label lane:docs --risk risk:yellow --changed-file projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md --output draft-pr` | 0 | `ACCEPT route=lane:docs` | `ACCEPT_LANE_DOCS_ROUTE` |
+| Wrong repo is rejected | `--repo alanua/Other --label lane:docs --risk risk:yellow --changed-file projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md --output draft-pr` | 1 | `REJECT route=lane:docs` | `REJECT_REPO_NOT_ALLOWED` |
+| Wrong lane is rejected | `--repo alanua/Knowledge-base --label lane:ops --risk risk:yellow --changed-file projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md --output draft-pr` | 1 | `REJECT route=lane:docs` | `REJECT_MISSING_LANE_DOCS` |
+| Forbidden script file is rejected | `--repo alanua/Knowledge-base --label lane:docs --risk risk:yellow --changed-file scripts/agent-dept/agent-dept-verify-lane-docs --output draft-pr` | 1 | `REJECT route=lane:docs` | `REJECT_FORBIDDEN_FILE_SCOPE` |
+| Index file without explicit index scope is rejected | `--repo alanua/Knowledge-base --label lane:docs --risk risk:yellow --changed-file projects/_index.md --output draft-pr` | 1 | `REJECT route=lane:docs` | `REJECT_INDEX_WITHOUT_EXPLICIT_SCOPE` |
+
+## Accepted Case Output
+
+```text
+ACCEPT route=lane:docs
+reason_codes=ACCEPT_LANE_DOCS_ROUTE
+repo=alanua/Knowledge-base
+risk=risk:yellow
+labels=lane:docs
+changed_files=projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md
+required_output=draft-pr
+would_call_live_runner=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_start_service=no
+would_touch_secrets=no
+```
+
+## Rejected Case Outputs
+
+Wrong repo:
+
+```text
+REJECT route=lane:docs
+reason_codes=REJECT_REPO_NOT_ALLOWED
+repo=alanua/Other
+risk=risk:yellow
+labels=lane:docs
+changed_files=projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md
+would_call_live_runner=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_start_service=no
+would_touch_secrets=no
+```
+
+Wrong lane:
+
+```text
+REJECT route=lane:docs
+reason_codes=REJECT_MISSING_LANE_DOCS
+repo=alanua/Knowledge-base
+risk=risk:yellow
+labels=lane:ops
+changed_files=projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md
+would_call_live_runner=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_start_service=no
+would_touch_secrets=no
+```
+
+Forbidden script file:
+
+```text
+REJECT route=lane:docs
+reason_codes=REJECT_FORBIDDEN_FILE_SCOPE
+repo=alanua/Knowledge-base
+risk=risk:yellow
+labels=lane:docs
+changed_files=scripts/agent-dept/agent-dept-verify-lane-docs
+would_call_live_runner=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_start_service=no
+would_touch_secrets=no
+```
+
+Index file without explicit index scope:
+
+```text
+REJECT route=lane:docs
+reason_codes=REJECT_INDEX_WITHOUT_EXPLICIT_SCOPE
+repo=alanua/Knowledge-base
+risk=risk:yellow
+labels=lane:docs
+changed_files=projects/_index.md
+would_call_live_runner=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_start_service=no
+would_touch_secrets=no
+```
+
+## Conclusion
+
+The verifier passed syntax, diff whitespace, built-in self-test, and the required manual acceptance/rejection checks for this controlled `Knowledge-base` `lane:docs` `risk:yellow` task.


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #49

## Scope

[agent-task-yellow] Verify lane-docs read-only verifier script

## Validation

```text
?? projects/jeeves/agent_runner_lane_docs_verifier_test_result_v1.md
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
