### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/projects/jeeves/runner_docs_once_wrapper_dry_run_result_v1.md
+++ b/projects/jeeves/runner_docs_once_wrapper_dry_run_result_v1.md
@@ -1,0 +1,80 @@
+# Runner Docs Once Wrapper Dry-Run Result v1
+
+Date: 2026-04-30
+Repository: `alanua/Knowledge-base`
+Wrapper: `scripts/agent-dept/agent-dept-runner-docs-once`
+Candidate issue: `#58`
+Task type: controlled `lane:docs` `risk:yellow` read-only dry-run
+
+## Scope
+
+This result records a successful read-only dry-run of
+`scripts/agent-dept/agent-dept-runner-docs-once` against test candidate issue
+`#58`.
+
+The dry-run proved read-only candidate selection only. It did not approve daemon
+mode, service installation, live runner replacement, issue claiming, label
+mutation, branch creation, PR creation, merge, deploy, or secret access.
+
+No live runner scripts, services, deployment/runtime paths, secrets, SSH keys, or
+environment values were edited or accessed as part of this result.
+
+## Observed Result
+
+```text
+status=eligible
+eligible=yes
+selection=one_candidate
+repo=alanua/Knowledge-base
+issue_number=58
+risk=risk:yellow
+labels=lane:docs
+changed_files=projects/jeeves/runner_docs_once_real_candidate_test_v1.md
+verifier_exit=0
+verifier_output=ACCEPT route=lane:docs
+would_claim_issue=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_call_live_runner=no
+would_edit_live_runner=no
+would_touch_secrets=no
+```
+
+## Interpretation
+
+The wrapper selected exactly one eligible candidate in read-only dry-run mode:
+`alanua/Knowledge-base#58`.
+
+The candidate was classified as `risk:yellow` and `lane:docs`, and the lane docs
+verifier accepted the proposed docs route with exit code `0`.
+
+All mutation and runtime action flags remained disabled:
+
+- no issue claim
+- no label mutation
+- no branch creation
+- no commit
+- no push
+- no PR creation
+- no merge
+- no deploy
+- no service start or installation
+- no live runner call or edit
+- no secret access
+
+## Conclusion
+
+This result supports only the narrow claim that
+`scripts/agent-dept/agent-dept-runner-docs-once` can identify an eligible docs
+candidate in read-only dry-run mode and route it through the lane docs verifier.
+
+It does not authorize or validate daemon mode, service installation, live runner
+replacement, issue claiming, label mutation, branch creation, PR creation,
+merge, deployment, runtime changes, or secret access.


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #59

## Scope

[agent-task-yellow] Record runner-docs once wrapper dry-run result

## Validation

```text
?? projects/jeeves/runner_docs_once_wrapper_dry_run_result_v1.md
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
