### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/projects/jeeves/runner_docs_fetch_metadata_test_result_v1.md
+++ b/projects/jeeves/runner_docs_fetch_metadata_test_result_v1.md
@@ -1,0 +1,93 @@
+# Runner Docs Fetch Metadata Test Result v1
+
+Date: 2026-05-01
+Repository: `alanua/Knowledge-base`
+Wrapper: `scripts/agent-dept/agent-dept-runner-docs-live-once`
+Candidate issue: `#71`
+Task type: controlled `lane:docs` `risk:yellow` read-only metadata fetch
+
+## Scope
+
+This result records a successful read-only `--fetch-metadata` test of
+`scripts/agent-dept/agent-dept-runner-docs-live-once` against issue `#71`.
+
+The test proves read-only metadata fetching and verifier routing only. It does
+not approve live mode, label mutation, branch creation, commit, push, draft PR
+creation, merge, daemon mode, service changes, deployment, live runner edits, or
+secret access.
+
+No live runner scripts, services, deployment/runtime paths, secrets, SSH keys, or
+environment values were edited or accessed as part of this result.
+
+## Observed Result
+
+```text
+status=accepted_fetch_metadata
+mode=fetch-metadata
+repo=alanua/Knowledge-base
+issue_number=71
+issue_state=OPEN
+risk=risk:yellow
+verifier_exit=0
+verifier_decision=accepted
+changed_files=projects/jeeves/runner_docs_fetch_metadata_candidate_test_v1.md
+labels_added=
+labels_removed=
+report_issue=none
+branch=none
+commit=none
+draft_pr=none
+validation=not_run
+recovery_action=none
+would_modify_labels=no
+would_create_report_issue=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+lane=lane:docs
+output=draft-pr
+one_explicit_issue_only=yes
+daemon_mode=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_edit_live_runner=no
+would_touch_secrets=no
+verifier_output=ACCEPT route=lane:docs
+```
+
+## Interpretation
+
+The wrapper fetched metadata for exactly one explicit issue:
+`alanua/Knowledge-base#71`.
+
+The fetched issue metadata routed as `risk:yellow` and `lane:docs`, and the lane
+docs verifier accepted the proposed docs route with exit code `0`.
+
+All mutation and runtime action fields remained disabled or absent:
+
+- no label mutation
+- no report issue creation
+- no branch creation
+- no commit
+- no push
+- no draft PR creation
+- no merge
+- no deploy
+- no service start or installation
+- no daemon mode
+- no live runner edit
+- no secret access
+
+## Conclusion
+
+This result supports only the narrow claim that
+`scripts/agent-dept/agent-dept-runner-docs-live-once --fetch-metadata` can fetch
+read-only metadata for one explicit docs issue and route it through the lane docs
+verifier.
+
+It does not authorize or validate live mode, label mutation, branch creation,
+commit, push, draft PR creation, merge, daemon mode, service changes,
+deployment, live runner edits, or secret access.


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #72

## Scope

[agent-task-yellow] Record runner-docs fetch-metadata test result

## Validation

```text
?? projects/jeeves/runner_docs_fetch_metadata_test_result_v1.md
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
