### PR TITLE
docs(jeeves): add runner health status

### DIFF
--- a/projects/jeeves/runner_health_status_2026_05_02_v1.md
+++ b/projects/jeeves/runner_health_status_2026_05_02_v1.md
@@ -1,0 +1,22 @@
+# Jeeves Runner Health Status — 2026-05-02
+
+GREEN:
+Queue-based GREEN runner entrypoint exists at `/home/agent/agent-dev/bin/agent-run-next-green` per the prior read-only inventory. It appears to select `risk:green` GitHub Issues, mutate runner state labels, and create reports. Current daemon/loop scheduler state was not proven by the docs-only inspection, so the safest status is: queue runner present, active invocation model unconfirmed.
+
+YELLOW:
+Queue-based YELLOW runner entrypoint exists at `/home/agent/agent-dev/bin/agent-run-next-yellow`, with setup/template carrier at `/home/agent/agent-dev/bin/agent-yellow-setup`. Prior inventory found the Knowledge-base `lane:docs` fallback in both files. Current evidence and recent runner history show YELLOW work being picked up from GitHub Issues, executed into branches, draft PRs, and report issues. Daemon/loop scheduler state was not proven here; the current safe model is issue/label queue execution, not markdown-file intake.
+
+RED:
+No active RED runner model is established in the inspected Jeeves docs/scripts for this lane. RED work remains outside this docs-only runner flow and should require explicit human approval and a separate task.
+
+CURRENT INTAKE CHANNEL:
+The active intake channel for this work is GitHub Issues in `alanua/Knowledge-base`, using issue labels. For the runner-docs live-once wrapper, required pickup labels are `agent:task`, `agent:queued`, exactly one `lane:docs`, and exactly one `risk:yellow`; the route is limited to `alanua/Knowledge-base` and docs files under `projects/jeeves/`, with `projects/_index.md` allowed only when explicit index maintenance is in scope. The docs lane output is a draft PR plus a separate runner report issue in live mode. Source-controlled dry-run wrappers remain read-only and report `would_claim=no`, `would_modify_labels=no`, and `would_create_pr=no`.
+
+WHY MARKDOWN TASK WAS NOT PICKED UP:
+The markdown task under `alanua/jeeves: knowledge_base/projects/jeeves/executor_tasks/2026-05-02_runner_health_cleanup.md` was in the wrong repository and the wrong intake shape. The observed runner flow does not scan `executor_tasks/` markdown files as its active queue. It selects open GitHub Issues in `alanua/Knowledge-base` with the required `agent:*`, `lane:*`, and `risk:*` labels, then uses the issue body as the task specification.
+
+CODEX WARNING INTERPRETATION:
+The repeated warning `failed to record rollout items: thread ... not found` was not found in the inspected source-controlled Jeeves docs/scripts, so the exact cause is unproven from this docs-only inspection. Best current classification: stale session metadata or runner/Codex workflow bookkeeping issue, likely harmless to task output. It does not appear to block runner output, because prior YELLOW runner history still produced branches, draft PRs, and report issues. Safest next action is to capture one fresh runner report/log occurrence in a separate read-only diagnostics task and correlate it with the Codex session/thread metadata, without editing runner scripts or changing services.
+
+NEXT SAFE ACTION:
+Keep this lane issue-based and docs-only. Do not replace live runner scripts, start daemons, change systemd, touch secrets, merge, or deploy from this task. The next implementation task should be a separate ChatGPT-reviewed YELLOW task to normalize the Knowledge-base `lane:docs` route into reviewed source-controlled runner behavior or an allowlist, while accounting for both `agent-run-next-yellow` and `agent-yellow-setup` before any later live change.


### PR DESCRIPTION
Replacement for draft PR #83.

Scope:
- adds `projects/jeeves/runner_health_status_2026_05_02_v1.md`
- docs-only
- no code, runtime, secrets, services, deploy, or merge automation changes

Review:
- ChatGPT reviewed draft PR #83 and found no blocking issues.
- This replacement exists only because the GitHub tool could not mark draft PR #83 ready for review.

After this PR is merged, draft PR #83 should be closed without merge.