### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/scripts/agent-dept/agent-dept-runner-docs-dry-run
+++ b/scripts/agent-dept/agent-dept-runner-docs-dry-run
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name=runner-docs
+repo target=alanua/Knowledge-base
+repo=alanua/Knowledge-base
+required labels: agent:task, agent:queued, risk:yellow, lane:docs
+compat runner label: runner:hetzner
+accepted runner labels=runner:hetzner-docs, runner:hetzner, runner:any
+accepted lane labels=lane:docs
+risk labels accepted=risk:green, risk:yellow
+blocking labels=blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF

--- a/scripts/agent-dept/agent-dept-runner-main-dry-run
+++ b/scripts/agent-dept/agent-dept-runner-main-dry-run
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name=runner-main
+repo target=alanua/Knowledge-base
+accepted runner labels=runner:hetzner-main, runner:hetzner, runner:any
+accepted lane labels=lane:implementation, lane:recovery
+risk labels accepted=risk:green, risk:yellow
+blocking labels=blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF

--- a/scripts/agent-dept/agent-dept-runner-tests-dry-run
+++ b/scripts/agent-dept/agent-dept-runner-tests-dry-run
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name=runner-tests
+repo target=alanua/Knowledge-base
+accepted runner labels=runner:hetzner-tests, runner:hetzner, runner:any
+accepted lane labels=lane:tests, lane:validate
+risk labels accepted=risk:green, risk:yellow
+blocking labels=blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF

--- a/scripts/agent-dept/agent-dept-status
+++ b/scripts/agent-dept/agent-dept-status
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+cat <<'EOF'
+mode=status
+read_only=yes
+lane name=agent-dept-status
+repo target=alanua/Knowledge-base
+accepted runner labels=reports configured dry-run wrapper files only
+accepted lane labels=reports configured dry-run wrapper files only
+risk labels accepted=reports configured dry-run wrapper files only
+blocking labels=blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF
+
+for wrapper in \
+  agent-dept-runner-main-dry-run \
+  agent-dept-runner-docs-dry-run \
+  agent-dept-runner-tests-dry-run \
+  agent-dept-watchdog-dry-run
+do
+  if [ -x "$script_dir/$wrapper" ]; then
+    echo "wrapper $wrapper=executable"
+  elif [ -f "$script_dir/$wrapper" ]; then
+    echo "wrapper $wrapper=present_not_executable"
+  else
+    echo "wrapper $wrapper=missing"
+  fi
+done

--- a/scripts/agent-dept/agent-dept-watchdog-dry-run
+++ b/scripts/agent-dept/agent-dept-watchdog-dry-run
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name=watchdog
+repo target=alanua/Knowledge-base
+accepted runner labels=none for claiming
+accepted lane labels=none for claiming
+risk labels accepted=none for claiming
+blocking labels=blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+health/status checks only=yes
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #118

## Scope

[agent-task-yellow] Implement dry-run wrappers with scripts allowlist

## Validation

```text
?? scripts/agent-dept/agent-dept-runner-docs-dry-run
?? scripts/agent-dept/agent-dept-runner-main-dry-run
?? scripts/agent-dept/agent-dept-runner-tests-dry-run
?? scripts/agent-dept/agent-dept-status
?? scripts/agent-dept/agent-dept-watchdog-dry-run
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
