### PR TITLE
chore(jeeves): add agent department dry-run wrapper scripts

### DIFF
--- a/scripts/agent-dept/agent-dept-runner-docs-dry-run
+++ b/scripts/agent-dept/agent-dept-runner-docs-dry-run
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name: runner-docs
+lane_name=runner-docs
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+required labels: agent:task, agent:queued, risk:yellow, lane:docs
+compat runner label: runner:hetzner
+accepted runner labels: runner:hetzner-docs, runner:hetzner, runner:any
+accepted lane labels: lane:docs
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF

--- a/scripts/agent-dept/agent-dept-runner-main-dry-run
+++ b/scripts/agent-dept/agent-dept-runner-main-dry-run
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name: runner-main
+lane_name=runner-main
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+accepted runner labels: runner:hetzner-main, runner:hetzner, runner:any
+accepted lane labels: lane:implementation, lane:recovery
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF

--- a/scripts/agent-dept/agent-dept-runner-tests-dry-run
+++ b/scripts/agent-dept/agent-dept-runner-tests-dry-run
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name: runner-tests
+lane_name=runner-tests
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+accepted runner labels: runner:hetzner-tests, runner:hetzner, runner:any
+accepted lane labels: lane:tests, lane:validate
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF

--- a/scripts/agent-dept/agent-dept-status
+++ b/scripts/agent-dept/agent-dept-status
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_root="${JEEVES_AGENT_DEPT_DRY_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/jeeves-agent-dept/dry-run}"
+
+cat <<EOF
+mode=status
+read_only=yes
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+lanes=runner-main,runner-docs,runner-tests,watchdog
+state_root=$state_root
+accepted runner labels: runner:hetzner-main, runner:hetzner-docs, runner:hetzner-tests, runner:hetzner, runner:any
+accepted lane labels: lane:implementation, lane:recovery, lane:docs, lane:tests, lane:validate
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF
+
+if [ -d "$state_root" ]; then
+  echo "dry_run_state_root_exists=yes"
+  for lane in hetzner-main hetzner-docs hetzner-tests hetzner-watchdog local-reserve-validator; do
+    log="$state_root/$lane.log"
+    if [ -f "$log" ]; then
+      printf 'log_present_%s=yes path=%s\n' "$lane" "$log"
+    else
+      printf 'log_present_%s=no path=%s\n' "$lane" "$log"
+    fi
+  done
+else
+  echo "dry_run_state_root_exists=no"
+fi

--- a/scripts/agent-dept/agent-dept-watchdog-dry-run
+++ b/scripts/agent-dept/agent-dept-watchdog-dry-run
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+mode=dry-run
+lane name: watchdog
+lane_name=watchdog
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+accepted runner labels: none for claiming
+accepted lane labels: none for claiming
+risk labels accepted: none for claiming
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+health_status_only=yes
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+EOF


### PR DESCRIPTION
Replacement for draft PR #121.

Scope:
- adds five dry-run/status scripts under `scripts/agent-dept/`:
  - `agent-dept-runner-main-dry-run`
  - `agent-dept-runner-docs-dry-run`
  - `agent-dept-runner-tests-dry-run`
  - `agent-dept-watchdog-dry-run`
  - `agent-dept-status`

Safety:
- dry-run/read-only scripts only
- all `would_*` fields report `no`
- no live runner script edits
- no systemd/service changes
- no secrets, tokens, SSH keys, env files, repo settings, deploys, or merge automation

Review:
- ChatGPT reviewed draft PR #121 and found no blocking issue.
- Runner reported `ERROR: forbidden file changed` despite issue #120 explicitly allowing `scripts/agent-dept/`; this appears to be a runner allowlist-reporting bug, not a scope violation.

After this PR is merged, draft PR #121 should be closed without merge.

Next:
- queue one docs-only validation task to run the new dry-run wrappers and capture output, without live service changes.