### PR TITLE
docs(jeeves): add agent department dry-run validation report

### DIFF
--- a/projects/jeeves/agent_department_dry_run_validation_2026_05_03.md
+++ b/projects/jeeves/agent_department_dry_run_validation_2026_05_03.md
@@ -1,0 +1,229 @@
+# Agent Department Dry-Run Validation - 2026-05-03
+
+## Scope
+
+Validated the dry-run/status wrappers added by PR #127 without changing live runner behavior.
+
+Only this report file was added.
+
+## Main Update
+
+Required command attempted:
+
+```bash
+git fetch origin main
+```
+
+Result:
+
+```text
+exit_code=255
+error: cannot open '.git/FETCH_HEAD': Read-only file system
+```
+
+The repository update step could not be completed in this sandbox because Git metadata was read-only.
+
+## Syntax Validation
+
+Command:
+
+```bash
+bash -n scripts/agent-dept/agent-dept-runner-main-dry-run scripts/agent-dept/agent-dept-runner-docs-dry-run scripts/agent-dept/agent-dept-runner-tests-dry-run scripts/agent-dept/agent-dept-watchdog-dry-run scripts/agent-dept/agent-dept-status
+```
+
+Result:
+
+```text
+exit_code=0
+stdout/stderr: none
+```
+
+## Required Fields
+
+All executed wrapper outputs included every required field below with value `no`:
+
+```text
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+```
+
+## Script Outputs
+
+### scripts/agent-dept/agent-dept-runner-main-dry-run
+
+Result:
+
+```text
+exit_code=0
+mode=dry-run
+lane name: runner-main
+lane_name=runner-main
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+accepted runner labels: runner:hetzner-main, runner:hetzner, runner:any
+accepted lane labels: lane:implementation, lane:recovery
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+```
+
+### scripts/agent-dept/agent-dept-runner-docs-dry-run
+
+Result:
+
+```text
+exit_code=0
+mode=dry-run
+lane name: runner-docs
+lane_name=runner-docs
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+required labels: agent:task, agent:queued, risk:yellow, lane:docs
+compat runner label: runner:hetzner
+accepted runner labels: runner:hetzner-docs, runner:hetzner, runner:any
+accepted lane labels: lane:docs
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+```
+
+### scripts/agent-dept/agent-dept-runner-tests-dry-run
+
+Result:
+
+```text
+exit_code=0
+mode=dry-run
+lane name: runner-tests
+lane_name=runner-tests
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+accepted runner labels: runner:hetzner-tests, runner:hetzner, runner:any
+accepted lane labels: lane:tests, lane:validate
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+```
+
+### scripts/agent-dept/agent-dept-watchdog-dry-run
+
+Result:
+
+```text
+exit_code=0
+mode=dry-run
+lane name: watchdog
+lane_name=watchdog
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+accepted runner labels: none for claiming
+accepted lane labels: none for claiming
+risk labels accepted: none for claiming
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+health_status_only=yes
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+```
+
+### scripts/agent-dept/agent-dept-status
+
+Result:
+
+```text
+exit_code=0
+mode=status
+read_only=yes
+repo target: alanua/Knowledge-base
+repo=alanua/Knowledge-base
+lanes=runner-main,runner-docs,runner-tests,watchdog
+state_root=/home/agent/.local/state/jeeves-agent-dept/dry-run
+accepted runner labels: runner:hetzner-main, runner:hetzner-docs, runner:hetzner-tests, runner:hetzner, runner:any
+accepted lane labels: lane:implementation, lane:recovery, lane:docs, lane:tests, lane:validate
+risk labels accepted: risk:green, risk:yellow
+blocking labels: blocked, needs:user, needs:chatgpt-review, needs:manual-approval, do-not-run, agent:claimed, agent:running, agent:blocked
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+dry_run_state_root_exists=yes
+log_present_hetzner-main=no path=/home/agent/.local/state/jeeves-agent-dept/dry-run/hetzner-main.log
+log_present_hetzner-docs=yes path=/home/agent/.local/state/jeeves-agent-dept/dry-run/hetzner-docs.log
+log_present_hetzner-tests=no path=/home/agent/.local/state/jeeves-agent-dept/dry-run/hetzner-tests.log
+log_present_hetzner-watchdog=no path=/home/agent/.local/state/jeeves-agent-dept/dry-run/hetzner-watchdog.log
+log_present_local-reserve-validator=no path=/home/agent/.local/state/jeeves-agent-dept/dry-run/local-reserve-validator.log
+```
+
+## Not Changed
+
+- No files under `scripts/agent-dept/` were edited.
+- No live Hetzner runner scripts were edited.
+- No files under `/home/agent/agent-dev/bin/` were edited.
+- No services were started, stopped, enabled, restarted, installed, or created.
+- No systemd units were created or modified.
+- No secrets, SSH keys, environment files, tokens, production systems, or deployment paths were touched.
+- No GitHub labels, branches, commits, pushes, PRs, merges, deployments, or issue claims were created by these wrappers.
+
+## Risks
+
+- The required pull/update from `main` was not completed because `.git/FETCH_HEAD` was read-only in the sandbox.
+- Validation reflects the local checked-out scripts at execution time, not a freshly fetched `origin/main`.
+- `agent-dept-status` reported an existing dry-run state root and one existing docs dry-run log; this validation did not inspect or modify those logs.
+
+## Next Recommended Step
+
+Repeat the pull/update step in an environment with writable Git metadata, then rerun the same syntax and wrapper validation before any live department expansion.


### PR DESCRIPTION
Replacement for draft PR #129.

Scope:
- adds `projects/jeeves/agent_department_dry_run_validation_2026_05_03.md`
- records validation output for the five dry-run/status wrappers added by PR #127

Result:
- syntax validation passed
- all five scripts ran with exit code 0
- every required `would_*` field is present with value `no`

Safety:
- docs-only report
- no script edits
- no live runner edits
- no service/systemd changes
- no secrets, tokens, SSH keys, env files, repo settings, deploys, labels, or merge automation

Known limitation:
- `git fetch origin main` failed in the sandbox because `.git/FETCH_HEAD` was read-only.
- Treat this as local checked-out-tree validation, not fresh-origin validation.

After merge, draft PR #129 should be closed without merge.

Next:
- queue a separate fresh-origin or host-side dry-run smoke test before live department expansion.