### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/projects/jeeves/agent_department_host_smoke_validation_2026_05_03.md
+++ b/projects/jeeves/agent_department_host_smoke_validation_2026_05_03.md
@@ -1,0 +1,206 @@
+# Jeeves Agent Department Host Smoke Validation - 2026-05-03
+
+## Scope
+
+This report records the requested host-side dry-run department smoke test for
+GitHub issue #132.
+
+Allowed output path:
+
+```text
+projects/jeeves/agent_department_host_smoke_validation_2026_05_03.md
+```
+
+No script edits, service changes, systemd changes, secrets access, deployment
+changes, live runner replacement, commits, pushes, merges, or PR creation were
+performed by this validation run.
+
+## Result
+
+Overall result: **blocked / not passed**.
+
+The dry-run wrapper and status scripts validated successfully, but the fresh
+origin update prerequisite did not succeed because this checkout still exposed a
+read-only `.git` write path:
+
+```text
+git fetch origin main
+error: cannot open '.git/FETCH_HEAD': Read-only file system
+```
+
+Because the requested validation specifically requires a normal writable host
+checkout, this run must not be used as the safety gate for live department
+expansion.
+
+## Fresh Origin Update
+
+Commands run:
+
+```bash
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+git rev-parse HEAD
+git status --short
+```
+
+Observed results:
+
+```text
+git fetch origin main
+exit=255
+error: cannot open '.git/FETCH_HEAD': Read-only file system
+
+git checkout main
+exit=128
+fatal: Unable to create '/home/agent/agent-dev/repos/Knowledge-base/.git/index.lock': Read-only file system
+
+git pull --ff-only origin main
+exit=1
+error: cannot open '.git/FETCH_HEAD': Read-only file system
+
+git rev-parse HEAD
+exit=0
+8de86eac0835430331124f2f9f6220abecb1eef5
+
+git status --short
+exit=0
+?? .codex
+```
+
+The commit SHA observed from the current checkout was:
+
+```text
+8de86eac0835430331124f2f9f6220abecb1eef5
+```
+
+This SHA was read successfully, but it was not validated after a successful
+fresh-origin update because fetch, checkout, and pull were blocked by the
+read-only `.git` filesystem state.
+
+The current branch observed during validation was:
+
+```text
+agent/yellow-kb-lane-docs-132-20260503-092256
+```
+
+## Syntax Validation
+
+Command run:
+
+```bash
+bash -n scripts/agent-dept/agent-dept-runner-main-dry-run scripts/agent-dept/agent-dept-runner-docs-dry-run scripts/agent-dept/agent-dept-runner-tests-dry-run scripts/agent-dept/agent-dept-watchdog-dry-run scripts/agent-dept/agent-dept-status
+```
+
+Result:
+
+```text
+exit=0
+```
+
+## Dry-Run And Status Commands
+
+Commands run:
+
+```bash
+scripts/agent-dept/agent-dept-runner-main-dry-run
+scripts/agent-dept/agent-dept-runner-docs-dry-run
+scripts/agent-dept/agent-dept-runner-tests-dry-run
+scripts/agent-dept/agent-dept-watchdog-dry-run
+scripts/agent-dept/agent-dept-status
+```
+
+Each command exited with status 0.
+
+For every dry-run/status output, the required fields were present with `no`:
+
+```text
+would_claim=no
+would_modify_labels=no
+would_create_branch=no
+would_commit=no
+would_push=no
+would_create_pr=no
+would_merge=no
+would_deploy=no
+would_start_service=no
+would_install_service=no
+would_touch_secrets=no
+```
+
+Observed command summaries:
+
+```text
+scripts/agent-dept/agent-dept-runner-main-dry-run
+exit=0
+mode=dry-run
+lane_name=runner-main
+repo=alanua/Knowledge-base
+all required would_* fields present with no
+
+scripts/agent-dept/agent-dept-runner-docs-dry-run
+exit=0
+mode=dry-run
+lane_name=runner-docs
+repo=alanua/Knowledge-base
+all required would_* fields present with no
+
+scripts/agent-dept/agent-dept-runner-tests-dry-run
+exit=0
+mode=dry-run
+lane_name=runner-tests
+repo=alanua/Knowledge-base
+all required would_* fields present with no
+
+scripts/agent-dept/agent-dept-watchdog-dry-run
+exit=0
+mode=dry-run
+lane_name=watchdog
+repo=alanua/Knowledge-base
+health_status_only=yes
+all required would_* fields present with no
+
+scripts/agent-dept/agent-dept-status
+exit=0
+mode=status
+read_only=yes
+repo=alanua/Knowledge-base
+lanes=runner-main,runner-docs,runner-tests,watchdog
+all required would_* fields present with no
+```
+
+## What Was Not Changed
+
+- No dry-run/status scripts were edited.
+- No live Hetzner runner scripts were edited.
+- No files under `/home/agent/agent-dev/bin/` were edited.
+- No services were started, stopped, enabled, restarted, or created.
+- No systemd units were created or changed.
+- No secrets, SSH keys, environment values, tokens, GitHub permissions, or
+  repository settings were touched.
+- No deployment paths were changed.
+- No labels were changed by the dry-run/status wrappers.
+- No issue was claimed by the dry-run/status wrappers.
+- No branch, commit, push, PR, merge, or deployment was created by the
+  dry-run/status wrappers.
+
+## Risks
+
+- The primary risk remains unresolved: the validation was not performed from a
+  checkout where `.git` was writable.
+- The observed current branch was not `main`, and checkout to `main` could not
+  complete because `.git/index.lock` could not be created.
+- The observed SHA was readable, but it was not confirmed against a freshly
+  fetched and fast-forwarded `origin/main`.
+- An existing untracked `.codex` path was present before this report was
+  written and was left untouched.
+
+## Recommended Next Step
+
+Repeat issue #132 from a genuinely writable host checkout of
+`alanua/Knowledge-base`, then rerun the same freshness, syntax, dry-run, and
+status commands before considering live department expansion beyond the current
+YELLOW/docs runner.
+
+ChatGPT review remains required before merge, and the user remains the final
+approver.


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #132

## Scope

[agent-task-yellow] Run host-side dry-run department smoke test

## Validation

```text
?? projects/jeeves/agent_department_host_smoke_validation_2026_05_03.md
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
