### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/scripts/agent-host-wrapper-reference/README.md
+++ b/scripts/agent-host-wrapper-reference/README.md
@@ -1,0 +1,74 @@
+# Agent Host Wrapper Reference
+
+Status: inert reference material only
+Scope: YELLOW host wrapper source-control normalization
+
+These files are source-controlled reference material for the YELLOW host wrapper
+family. They are not installed automatically, are not executable entry points,
+and are not a live runner implementation.
+
+This directory does not authorize live edits to:
+
+```text
+/home/agent/agent-dev/bin/*
+```
+
+Any future live apply to host-local wrapper files requires a separate explicit
+approval. That approval must name the live target files, the intended patch, and
+the validation to run after apply.
+
+Future fresh-origin gate implementation must be reviewed in source control
+before any host apply. The reviewed implementation should cover the gate
+insertion point, metadata handoff, setup-carrier sync, dirty-worktree policy,
+and privacy boundaries before a manual host-local apply task is considered.
+
+## Source Inputs
+
+The reference files follow these source-controlled reports:
+
+```text
+projects/jeeves/host_wrapper_fresh_origin_gate_design_2026_05_03.md
+projects/jeeves/host_wrapper_fresh_origin_gate_insertion_point_2026_05_03.md
+projects/jeeves/yellow_host_wrapper_source_control_normalization_2026_05_03.md
+```
+
+The host-local wrapper family was inspected only through the bounded,
+public-safe ranges allowed by the task:
+
+```text
+/home/agent/agent-dev/bin/agent-run-yellow-loop
+/home/agent/agent-dev/bin/agent-run-next-yellow
+/home/agent/agent-dev/bin/agent-yellow-setup
+```
+
+No env files, token files, SSH configs, credential helper output, broad host
+inventory, repo settings, service state, private logs, deployment paths, or
+secret material were read or copied into these references.
+
+## Redaction And Abstraction
+
+The `.reference.sh` files are abstracted comment-only references. They preserve
+public-safe structure and insertion-point guidance while omitting executable
+runner behavior. They intentionally do not include a working installer, live
+apply script, systemd unit, service command, credential output, token, SSH key,
+env value, private host inventory, repo setting, broad log, or deployment
+secret.
+
+## Non-Authorization
+
+These files do not authorize:
+
+- installing, copying, symlinking, or chmodding host scripts;
+- editing `/home/agent/agent-dev/bin/*`;
+- starting, stopping, enabling, restarting, or creating services;
+- rerunning issue #147 automatically;
+- expanding runner authority;
+- expanding the live development department;
+- changing Jeeves runtime behavior;
+- merging, deploying, or touching production systems.
+
+## Next Recommendation
+
+Prepare a reviewed fresh-origin gate reference implementation in source control
+or create a separate explicit manual host apply task. ChatGPT review and user
+approval remain required before any live host edit.

--- a/scripts/agent-host-wrapper-reference/agent-run-next-yellow.reference.sh
+++ b/scripts/agent-host-wrapper-reference/agent-run-next-yellow.reference.sh
@@ -1,0 +1,107 @@
+# -----------------------------------------------------------------------------
+# INERT REFERENCE ONLY - DO NOT INSTALL OR EXECUTE
+# -----------------------------------------------------------------------------
+#
+# Reference target:
+#   agent-run-next-yellow
+#
+# Source relationship:
+#   This comment-only reference summarizes the public-safe structure observed in
+#   the bounded host-side read allowed by the YELLOW source-control
+#   normalization task and the prior source-controlled design reports.
+#
+# Redaction/abstraction:
+#   No live host script was copied verbatim. This file omits executable shell,
+#   host mutation, service control, secrets, env values, credential material,
+#   private inventory, broad logs, repo settings, and deployment details.
+#
+# Public-safe structural outline:
+#
+#   - select host or local runner labels from the current host identity
+#   - create a per-run artifact directory
+#   - use a lock to avoid concurrent YELLOW runner execution
+#   - search configured GitHub repositories for open queued YELLOW tasks
+#   - record the issue body into the run directory
+#   - best-effort mark the issue claimed/running and post a start comment
+#   - map supported repository names to local checkout paths
+#   - prepare a task branch
+#   - construct a controlled YELLOW Codex prompt from:
+#       * absolute runner rules
+#       * explicit allowed files
+#       * issue body
+#       * route-specific implementation instruction
+#   - start Codex with the selected repository checkout
+#   - remove transient Codex/FETCH_HEAD artifacts after Codex returns
+#   - reject direct Codex-created commits before validation/commit
+#   - collect changed files and validate them against route-specific allowlists
+#   - run route-specific validation
+#   - create a draft PR after validation in the live wrapper path
+#
+# Current Knowledge-base lane:docs flow, summarized:
+#
+#   run_kb_yellow_generic_docs_lane()
+#     -> prepare_branch(repo_dir, branch)
+#     -> run_codex_yellow(repo_dir, allowed_text, task_text)
+#     -> ensure_no_codex_commit()
+#     -> changed_files()
+#     -> validate_allowed_files(...)
+#     -> validate_kb()
+#     -> create_draft_pr(...)
+#
+# Fresh-origin gate insertion point for future reviewed implementation:
+#
+#   Function:
+#     prepare_branch()
+#
+#   Boundary:
+#     after entering the repository checkout and before switching/pulling main,
+#     cleaning transient files, checking dirty state, or creating the task branch
+#
+#   Reviewed helper responsibilities:
+#     - verify expected repository identity and origin URL
+#     - fetch or update origin/main from host context
+#     - update only by fast-forward
+#     - record host freshness timestamp
+#     - record verified HEAD SHA
+#     - record clean/dirty state without exposing private data
+#     - fail closed on malformed or missing freshness metadata
+#     - fail closed on dirty state unless a later reviewed exception exists
+#
+# Metadata handoff insertion point for future reviewed implementation:
+#
+#   Function:
+#     run_codex_yellow()
+#
+#   Boundary:
+#     before Codex starts, include minimal host freshness metadata in the prompt
+#     or run context so Codex can compare local HEAD with the host-verified SHA
+#
+# Minimal public-safe metadata fields for a future reviewed implementation:
+#
+#   repository=alanua/Knowledge-base
+#   remote_url=https://github.com/alanua/Knowledge-base.git
+#   branch=main
+#   host_freshness_checked_at_utc=<ISO-8601 timestamp>
+#   host_freshness_command_set=fetch_plus_ff_only_update
+#   host_verified_head_sha=<40-character commit SHA>
+#   host_worktree_clean=yes|no
+#   host_status_short_allowed_entries=<integer>
+#   host_status_short_allowed_paths=<empty or reviewed public-safe path list>
+#   host_update_mode=existing_checkout
+#   runner_lane=lane:docs
+#   risk=risk:yellow
+#   source_issue=<issue number>
+#
+# Privacy and safety boundaries:
+#
+#   - do not print tokens, SSH keys, env values, credential helper output, repo
+#     settings, broad logs, private host inventory, or deployment secrets
+#   - do not perform broad host diagnostics
+#   - do not change firewall, network, container, service, or systemd state
+#   - do not rerun issue #147 automatically
+#   - do not expand runner authority or live development department behavior
+#
+# Non-authorization:
+#
+#   This reference must not be installed, executed, chmodded executable, copied
+#   over /home/agent/agent-dev/bin/*, or used as authority for a live host edit.

--- a/scripts/agent-host-wrapper-reference/agent-run-yellow-loop.reference.sh
+++ b/scripts/agent-host-wrapper-reference/agent-run-yellow-loop.reference.sh
@@ -1,0 +1,35 @@
+# -----------------------------------------------------------------------------
+# INERT REFERENCE ONLY - DO NOT INSTALL OR EXECUTE
+# -----------------------------------------------------------------------------
+#
+# Reference target:
+#   agent-run-yellow-loop
+#
+# Source relationship:
+#   This comment-only reference summarizes the public-safe structure observed in
+#   the bounded host-side read allowed by the YELLOW source-control
+#   normalization task.
+#
+# Redaction/abstraction:
+#   No live host script was copied verbatim. This file omits executable shell,
+#   host mutation, service control, secrets, env values, credential material,
+#   private inventory, and broad logs.
+#
+# Structural outline:
+#
+#   - read an optional batch count, defaulting to one task
+#   - for each batch slot, invoke the next-task YELLOW wrapper
+#   - print child output for operator visibility
+#   - stop cleanly when the next-task wrapper reports no queued YELLOW task
+#   - stop cleanly when the next-task wrapper reports runner lock contention
+#   - print a loop-complete marker after the requested batch count
+#
+# Fresh-origin relevance:
+#
+#   This loop wrapper is not the fresh-origin gate insertion point. It delegates
+#   repository preparation and Codex sandbox startup to the next-task wrapper.
+#
+# Non-authorization:
+#
+#   This reference must not be installed, executed, chmodded executable, copied
+#   over /home/agent/agent-dev/bin/*, or used as authority for a live host edit.

--- a/scripts/agent-host-wrapper-reference/agent-yellow-setup.reference.sh
+++ b/scripts/agent-host-wrapper-reference/agent-yellow-setup.reference.sh
@@ -1,0 +1,47 @@
+# -----------------------------------------------------------------------------
+# INERT REFERENCE ONLY - DO NOT INSTALL OR EXECUTE
+# -----------------------------------------------------------------------------
+#
+# Reference target:
+#   agent-yellow-setup
+#
+# Source relationship:
+#   This comment-only reference summarizes the public-safe setup-carrier role
+#   observed in the bounded host-side read allowed by the YELLOW source-control
+#   normalization task.
+#
+# Redaction/abstraction:
+#   No live host setup script was copied verbatim. This file omits executable
+#   shell, heredoc installer content, host mutation, service control, secrets,
+#   env values, credential material, private inventory, broad logs, repo
+#   settings, and deployment details.
+#
+# Public-safe structural outline:
+#
+#   - create host-local runner support directories
+#   - choose host-local or local-WSL wrapper command names from host identity
+#   - define runner log and PID file paths for the selected mode
+#   - write the next-task wrapper from a template/heredoc
+#   - write the loop wrapper from a template/heredoc
+#   - write daemon/start/status/stop helper wrappers in the live setup path
+#
+# Fresh-origin relevance:
+#
+#   The setup carrier can recreate the next-task wrapper. Any future reviewed
+#   change to the live next-task wrapper must therefore be mirrored in the setup
+#   carrier before host apply, otherwise setup/reinstall can restore an older
+#   wrapper without the reviewed gate.
+#
+# Future reviewed implementation checklist:
+#
+#   - keep setup-carrier content synchronized with the reviewed
+#     agent-run-next-yellow fresh-origin gate implementation
+#   - keep generated scripts privacy-bounded
+#   - keep host freshness metadata minimal and public-safe
+#   - fail closed if repository freshness cannot be proven
+#   - avoid service changes unless a separate explicit task approves them
+#
+# Non-authorization:
+#
+#   This reference must not be installed, executed, chmodded executable, copied
+#   over /home/agent/agent-dev/bin/*, or used as authority for a live host edit.


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #174

## Scope

[agent-task-yellow] Add inert YELLOW host wrapper reference files

## Validation

```text
?? scripts/agent-host-wrapper-reference/
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
