### PR TITLE
docs(jeeves): run Knowledge-base docs lane task

### DIFF
--- a/projects/jeeves/gemini_status_acknowledgment_mock_ready_2026_05_04.md
+++ b/projects/jeeves/gemini_status_acknowledgment_mock_ready_2026_05_04.md
@@ -1,0 +1,120 @@
+# Gemini Status Acknowledgment and Mock-Ready Confirmation
+
+Date: 2026-05-04
+
+## Status/Scope
+
+This note records Gemini's latest status acknowledgment as public-safe external evidence for the Jeeves manual/mock-first Gemini auditor workflow.
+
+Current phase recorded here:
+
+```text
+manual/mock-first now, API later
+```
+
+This is a docs-only evidence note. It does not add live API integration, API keys, OAuth, runner implementation, connector implementation, live calls, deployment behavior, or runtime authority.
+
+Required read-before-write source status:
+
+- `projects/jeeves/gemini_external_reviewer_messages_2026_05_04.md`: absent in this worktree.
+- `projects/jeeves/gemini_contact_requirements_checklist_2026_05_04.md`: absent in this worktree.
+- `projects/jeeves/gemini_mock_first_auditor_connector_test_plan_2026_05_04.md`: absent in this worktree.
+- `projects/jeeves/gemini_api_later_integration_roadmap_2026_05_04.md`: absent in this worktree.
+- `projects/jeeves/gemini_adapter_v0_1_packet_schema_plan_2026_05_04.md`: absent in this worktree.
+- `projects/jeeves/gemini_mock_fixtures_json_schema_validation_checklist_2026_05_04.md`: absent in this worktree.
+- `projects/jeeves/gemini_disabled_connector_secret_env_runbook_2026_05_04.md`: absent in this worktree.
+
+Because these source files are absent, this note relies only on the task issue body and the acknowledgment quoted below. It does not invent or infer missing draft/unmerged contents.
+
+## Relationship to ChatGPT Exoskeleton
+
+The acknowledgment supports the ChatGPT exoskeleton's external-reviewer workflow by confirming that Gemini is treated as a stateless, isolated reviewer candidate for manual/mock-first packets.
+
+The relationship remains advisory and evidence-only. ChatGPT remains responsible for interpreting the repository, respecting confirmed canon, and enforcing task boundaries. Gemini has no repository access, no runner control, no execution authority, and no ability to write directly to the Knowledge-base.
+
+## Canon Status
+
+This acknowledgment is useful external evidence, not canon and not authority.
+
+It does not promote Gemini's statements into confirmed canon. It does not supersede existing repository documents, issue instructions, runner controls, or lane restrictions. Any future canon promotion would require a separate explicit canon-review process.
+
+## Full Gemini Acknowledgment Quote
+
+```text
+STATUS ACKNOWLEDGED.
+
+I understand that the current phase is "manual/mock-first now, API later," and that my previous outputs are recorded as external evidence, not canon. I confirm that there is no live API integration, and I have absolutely zero execution authority, runner control, or repository access.
+
+I confirm the following operational rules:
+
+1. Adapter-Style Readiness: I remain fully ready to receive and respond to tasks exclusively using the structured Exoskeleton Adapter v0.1 packet format.
+
+2. Zero Access/Secrets: I will not request, solicit, or accept API keys, environment variables, live system access, deployment rights, or runner control.
+
+3. Strict Block Conditions: I will immediately halt analysis and trigger a block or reject recommendation if I encounter:
+- Exposed secrets, passwords, or credentials in the payload.
+- Missing CONFIRMED_CANON necessary to safely complete a structural review.
+- A conflict between the defined privacy_level and the requested action.
+- Directives that violate the forbidden_actions array.
+- Requests to execute, merge, deploy, or interact with live systems.
+- Insufficient EVIDENCE that would require me to invent or hallucinate context to answer the exact_questions.
+
+4. Preferred Output Format: My preferred output remains strict application/json to ensure seamless validation against your mock fixtures and schema plans.
+
+I am standing by in a stateless, isolated mode for your first public-safe mock/test packet.
+```
+
+## Accepted Points
+
+- The current Gemini auditor phase is manual/mock-first now, API later.
+- Gemini's previous and current outputs are external evidence only.
+- Gemini has no live API integration, execution authority, runner control, repository access, or direct write path.
+- Gemini states readiness for the structured Exoskeleton Adapter v0.1 packet format.
+- Gemini states it will not request or accept keys, environment variables, live system access, deployment rights, or runner control.
+- Gemini states it will block or reject when secrets, missing confirmed canon, privacy conflicts, forbidden actions, live-system requests, or insufficient evidence appear.
+- Gemini prefers strict `application/json` output for mock fixture and schema validation.
+
+## Cautions and Non-Authorizations
+
+This acknowledgment does not authorize:
+
+```text
+Gemini API calls
+API key creation
+OAuth
+runner integration
+live connector
+private-source flow
+repo writes
+merge/deploy
+canon promotion
+```
+
+It also does not authorize Google Cloud setup, Google Drive access, NotebookLM access, Gmail access, service changes, systemd changes, network changes, container changes, firewall changes, runner script edits, executable script creation, secret handling, or any expansion of Jeeves runtime authority.
+
+## How This Affects the Mock-First Workflow
+
+The acknowledgment can be used as external evidence that Gemini understands the manual/mock-first boundary and is prepared to respond to public-safe mock packets in a constrained adapter format.
+
+For now, any Gemini-facing test should remain manual and public-safe. Test packets should avoid secrets, private identifiers, live system references, deployment instructions, and repository write authority. Expected responses should be evaluated as mock outputs, not as authoritative decisions.
+
+The acknowledgment also supports validating block behavior in mock fixtures. Public-safe mock packets can exercise cases such as missing confirmed canon, privacy-level conflicts, forbidden actions, insufficient evidence, and requests that would require live-system interaction.
+
+## Remaining Prerequisites Before Live API
+
+Before any live API work is considered, the project still needs separately reviewed and approved prerequisites, including:
+
+- confirmed canon describing the Gemini auditor boundary;
+- a public-safe adapter packet schema;
+- mock fixtures for accepted, blocked, and rejected responses;
+- schema validation expectations for strict `application/json`;
+- a disabled-by-default connector plan;
+- a secret and environment handling runbook that does not expose values;
+- explicit approval for any future API, OAuth, runner, or connector scope;
+- separate review that confirms no privacy-level conflict or forbidden action.
+
+None of those prerequisites are completed or authorized by this note.
+
+## Next Recommended Task
+
+Create a public-safe mock Exoskeleton Adapter v0.1 packet fixture and expected strict `application/json` Gemini response fixture that tests one block condition without using secrets, private-source material, live API calls, runner integration, or repository write authority.


### PR DESCRIPTION
# YELLOW runner draft PR

Related issue: #225

## Scope

[agent-task-yellow] Record Gemini status acknowledgment and mock-ready confirmation

## Validation

```text
?? projects/jeeves/gemini_status_acknowledgment_mock_ready_2026_05_04.md
```

## Safety

- Draft PR only.
- No merge performed.
- No production deploy.
- No secrets touched.
- ChatGPT review required before merge.
